### PR TITLE
斗胆修改自定义选择器视图重复问题

### DIFF
--- a/rollviewpager/src/main/java/com/jude/rollviewpager/RollPagerView.java
+++ b/rollviewpager/src/main/java/com/jude/rollviewpager/RollPagerView.java
@@ -13,9 +13,8 @@ import android.support.v4.view.ViewPager.OnPageChangeListener;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.View;
-import android.view.animation.Interpolator;
 import android.view.ViewGroup;
-import android.view.animation.AccelerateInterpolator;
+import android.view.animation.Interpolator;
 import android.widget.RelativeLayout;
 import android.widget.Scroller;
 
@@ -248,6 +247,7 @@ public class RollPagerView extends RelativeLayout implements OnPageChangeListene
 		if (!(hintview instanceof View)){
 			throw new IllegalArgumentException("HintView should be a View");
 		}
+		removeView(mHintView);
 		this.mHintView = (View) hintview;
 		initHint(hintview);
 	}

--- a/rollviewpager/src/main/java/com/jude/rollviewpager/RollPagerView.java
+++ b/rollviewpager/src/main/java/com/jude/rollviewpager/RollPagerView.java
@@ -247,7 +247,9 @@ public class RollPagerView extends RelativeLayout implements OnPageChangeListene
 		if (!(hintview instanceof View)){
 			throw new IllegalArgumentException("HintView should be a View");
 		}
-		removeView(mHintView);
+		if (mHintView != null) {
+			removeView(mHintView);
+		}
 		this.mHintView = (View) hintview;
 		initHint(hintview);
 	}


### PR DESCRIPTION
问题：如果XML中不小心设置了mode，再使用自定义选择器会出现重复问题

（情况如下图所示）

![452bd4f9-fc8e-4543-bd74-01e029658ffc](https://cloud.githubusercontent.com/assets/10269126/11324530/5cfcc3b4-916f-11e5-9196-576917323697.png)

**RollPageView.java**

- 出现问题版

```java
	public void setHintView(HintView hintview){
		if (!(hintview instanceof View)){
			throw new IllegalArgumentException("HintView should be a View");
		}
// 在设置选择器的时候修改了mHintView，所以在initHint()中无法移除之前的视图了
		this.mHintView = (View) hintview;
		initHint(hintview);
	}
```
- 斗胆修改版

```java
	public void setHintView(HintView hintview){
		if (!(hintview instanceof View)){
			throw new IllegalArgumentException("HintView should be a View");
		}
// 在修改之前，如果之前有视图，就把它给移除掉~
// -----------------------------------------------------------------
		if (mHintView != null) {
			removeView(mHintView);
		}
// -----------------------------------------------------------------
		this.mHintView = (View) hintview;
		initHint(hintview);
	}
```