### PR TITLE
notifyDataSetChanged invalid

### DIFF
--- a/rollviewpager/src/main/java/com/jude/rollviewpager/adapter/LoopPagerAdapter.java
+++ b/rollviewpager/src/main/java/com/jude/rollviewpager/adapter/LoopPagerAdapter.java
@@ -32,6 +32,12 @@ public abstract class LoopPagerAdapter extends PagerAdapter{
                 hintView.initView(getRealCount(),gravity);
         }
     }
+    @Override
+    public void notifyDataSetChanged() {
+        super.notifyDataSetChanged();
+        mViewList.clear();
+
+    }
 
     @Override
     public void registerDataSetObserver(DataSetObserver observer) {


### PR DESCRIPTION
when user use notifyDataSetChanged(), this method can be valid only when  refresh all the data source .